### PR TITLE
Revert to connect in the constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ authors = ["Miyoshi-Ryota <m1yosh1.ry0t4@gmail.com>"]
 openssl = ["russh/openssl"]
 
 [dependencies]
-russh = "0.34.0"
-russh-keys = "0.22.0"
+russh = "0.36.1"
+russh-keys = "0.24.1"
 thiserror = "1.0"
+async-trait = "0.1.61"
 
 [dev-dependencies]
 tokio = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-ssh2-tokio"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license-file = "LICENSE"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for rust with the tokio runtime. Powered by the rust ssh implementation
 ```rust
 [dependencies]
 tokio = "1"
-async-ssh2-tokio = "0.4.0"
+async-ssh2-tokio = "0.5.0"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # async-ssh2-tokio
 ![Unit Test Status](https://github.com/Miyoshi-Ryota/async-ssh2-tokio/actions/workflows/ci.yml/badge.svg)
 ![Lint Status](https://github.com/Miyoshi-Ryota/async-ssh2-tokio/actions/workflows/super_lint.yml/badge.svg)
-
-This library is a asynchronous and easy-to-use high level ssh client library
-for rust with the tokio runtime. Powered by russh.
-
 [Docs.rs](https://docs.rs/async-ssh2-tokio/latest/async_ssh2_tokio/),
 [Crates.io](https://crates.io/crates/async-ssh2-tokio)
 
+This library is an asynchronous and easy-to-use high level ssh client library
+for rust with the tokio runtime. Powered by the rust ssh implementation
+[russh](https://github.com/warp-tech/russh).
+
 
 ## Features
-* Connect to SSH Host via IP and password.
+* Connect to a SSH Host via IP and password
 * Execute commands on the remote host
+* Get the stdout and exit code of the command
 
 ## Install
 ```rust
@@ -53,4 +54,4 @@ or set the following environment variables for a working ssh host:
 * `ASYNC_SSH2_TEST_HOST_USER`: The username to connect as.
 * `ASYNC_SSH2_TEST_HOST_PW`: The corresponding password. Since this is plain text, creating a new unpriviledged user is recommended.
 
-Note: The doc tests do not use these variables and are therefor not run, but only compiled.
+Note: The doc tests do not use these variables and are therefore not run, but only compiled.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # async-ssh2-tokio
 ![Unit Test Status](https://github.com/Miyoshi-Ryota/async-ssh2-tokio/actions/workflows/ci.yml/badge.svg)
 ![Lint Status](https://github.com/Miyoshi-Ryota/async-ssh2-tokio/actions/workflows/super_lint.yml/badge.svg)
+
+This library is a asynchronous and easy-to-use high level ssh client library
+for rust with the tokio runtime. Powered by russh.
+
 [Docs.rs](https://docs.rs/async-ssh2-tokio/latest/async_ssh2_tokio/),
 [Crates.io](https://crates.io/crates/async-ssh2-tokio)
 
-This library is an asynchronous and easy-to-use high level ssh client library
-for rust with the tokio runtime. Powered by the rust ssh implementation
-[russh](https://github.com/warp-tech/russh).
-
 
 ## Features
-* Connect to a SSH Host via IP and password
+* Connect to SSH Host via IP and password.
 * Execute commands on the remote host
-* Get the stdout and exit code of the command
 
 ## Install
 ```rust
@@ -28,11 +27,11 @@ use async_ssh2_tokio::client::{Client, AuthMethod};
 async fn main() -> Result<(), async_ssh2_tokio::Error> {
     // Only ip and password based authentification is implemented.
     // If you need key based authentification, create github issue or contribute.
-    let mut client = Client::new(
+    let mut client = Client::connect(
         ("10.10.10.2", 22),
         "root",
         AuthMethod::with_password("root"),
-    )?;
+    ).await?;
 
     let result = client.execute("echo Hello SSH").await?;
     assert_eq!(result.output, "Hello SSH\n");
@@ -54,4 +53,4 @@ or set the following environment variables for a working ssh host:
 * `ASYNC_SSH2_TEST_HOST_USER`: The username to connect as.
 * `ASYNC_SSH2_TEST_HOST_PW`: The corresponding password. Since this is plain text, creating a new unpriviledged user is recommended.
 
-Note: The doc tests do not use these variables and are therefore not run, but only compiled.
+Note: The doc tests do not use these variables and are therefor not run, but only compiled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
-//! This library is an asynchronous and easy-to-use high level ssh client library
-//! for rust with the tokio runtime. Powered by the rust ssh implementation
-//! [russh](https://github.com/warp-tech/russh), a fork of thrussh.
+//! This library, async-ssh2-tokio, is a asynchronous and super-easy-to-use high level ssh client library for rust.
+//! Powered by russh, a fork of thrussh.
 //!
 //! The heart of this library is [`client::Client`]. Use this for connection, authentification and execution.
 //!
 //! # Features
-//! * Connect to a SSH Host via IP and password
+//! * Connect to SSH Host via IP and password.
 //! * Execute commands on the remote host
-//! * Get the stdout and exit code of the command
 //!
 //! # Example
 //! ```no_run
@@ -16,11 +14,11 @@
 //! async fn main() -> Result<(), async_ssh2_tokio::Error> {
 //!     // Only ip and password based authentification is implemented.
 //!     // If you need key based authentification, create github issue or contribute.
-//!     let mut client = Client::new(
+//!     let mut client = Client::connect(
 //!         ("10.10.10.2", 22),
 //!         "root",
 //!         AuthMethod::with_password("root"),
-//!     )?;
+//!     ).await?;
 //!
 //!     let result = client.execute("echo Hello SSH").await?;
 //!     assert_eq!(result.output, "Hello SSH\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! The heart of this library is [`client::Client`]. Use this for connection, authentification and execution.
 //!
 //! # Features
-//! * Connect to a SSH Host via IP and password.
+//! * Connect to a SSH Host via IP and password
 //! * Execute commands on the remote host
 //! * Get the stdout and exit code of the command
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
-//! This library, async-ssh2-tokio, is a asynchronous and super-easy-to-use high level ssh client library for rust.
-//! Powered by russh, a fork of thrussh.
+//! This library is an asynchronous and easy-to-use high level ssh client library
+//! for rust with the tokio runtime. Powered by the rust ssh implementation
+//! [russh](https://github.com/warp-tech/russh), a fork of thrussh.
 //!
 //! The heart of this library is [`client::Client`]. Use this for connection, authentification and execution.
 //!
 //! # Features
-//! * Connect to SSH Host via IP and password.
+//! * Connect to a SSH Host via IP and password.
 //! * Execute commands on the remote host
+//! * Get the stdout and exit code of the command
 //!
 //! # Example
 //! ```no_run


### PR DESCRIPTION
Upgraded to russh version that properly closes channels, permitting unlimited sequential executes over a single connection. The aforementioned limit on open channels still applies and restricts the number of simultaneous executes.